### PR TITLE
Feature to disable bottom lidar filters and reduce lidar FOV

### DIFF
--- a/CHANGELOG_KABAM.md
+++ b/CHANGELOG_KABAM.md
@@ -1,0 +1,18 @@
+# Change log for rplidar_ros package (KABAM Robotics version)
+
+## 0.2.0-dev [2025-01-09]
+- Added arg to enable and disable bottom lidar left, right and rear filters.
+- Changed `static_transform_publisher` package to use `tf2_ros` package.
+- Changed launch file formatting.
+- Reduced bottom lidar filter field of view.
+
+## 0.1.0 [2023-06-05]
+- Added `Dockerfile` to dockerize this package.
+- Added launch files for side lidar and bottom lidar.
+- Added filters for bottom lidar.
+
+---
+
+## Upstream History
+
+This project is forked from [Slamtec/rplidar_ros](https://github.com/Slamtec/rplidar_ros). Refer to [this](./CHANGELOG.rst) for the original repository's changelog up to `v2.0.0`.

--- a/README.md
+++ b/README.md
@@ -148,3 +148,7 @@ Notice: different lidar use different serial_baudrate.
 ## RPLidar frame
 
 RPLidar frame must be broadcasted according to picture shown in rplidar-frame.png
+
+---
+
+Refer to [this](./CHANGELOG_KABAM.md) for KABAM's release notes

--- a/configs/bottom_lidar_filter_left.yaml
+++ b/configs/bottom_lidar_filter_left.yaml
@@ -2,5 +2,5 @@ scan_filter_chain:
 - name: angle_filter
   type: laser_filters/LaserScanAngularBoundsFilter
   params:
-    lower_angle: 1.396
+    lower_angle: 1.696
     upper_angle: 3.142

--- a/configs/bottom_lidar_filter_right.yaml
+++ b/configs/bottom_lidar_filter_right.yaml
@@ -3,4 +3,4 @@ scan_filter_chain:
   type: laser_filters/LaserScanAngularBoundsFilter
   params:
     lower_angle: -3.142
-    upper_angle: -1.396
+    upper_angle: -1.696

--- a/launch/bottom_lidar.launch
+++ b/launch/bottom_lidar.launch
@@ -1,49 +1,67 @@
 <launch>
     <arg name="bottom_laser" value="0.4859 0 0.1248 3.142 0 3.142 base_link bottom_laser_link"/>
-    <arg name="bottom_lidar_filter_enable"    value="$(optenv BOTTOM_LIDAR_FILTER_ENABLE false)"/>
+    <arg name="bottom_lidar_driver_enable"      value="$(optenv BOTTOM_LIDAR_DRIVER_ENABLE true)"/>
+    <arg name="bottom_lidar_filter_enable"      value="$(optenv BOTTOM_LIDAR_FILTER_ENABLE true)"/>
+    <arg name="bottom_lidar_back_filter_enable" value="$(optenv BOTTOM_LIDAR_BACK_FILTER_ENABLE false)"/>
 
     <env name="ROSCONSOLE_CONFIG_FILE" value="$(find rplidar_ros)/configs/custom_rosconsole.conf"/>
 
     <node pkg="tf2_ros" type="static_transform_publisher" name="bottom_laser_tf" args="$(arg bottom_laser)" />
 
-    <node name="bottom_rplidar_node" pkg="rplidar_ros" type="rplidarNode" output="screen">
-        <param name="channel_type"        type="string" value="udp"/>  
-        <param name="udp_ip"              type="string" value="10.7.5.151"/>  
-        <param name="frame_id"            type="string" value="bottom_laser_link"/>
-        <param name="inverted"            type="bool"   value="false"/>
-        <param name="angle_compensate"    type="bool"   value="true"/>
-        <param name="scan_mode"           type="string" value="Sensitivity"/>
-        <param name="scan_frequency"      type="int"  value="10"/>
-        <remap from="scan" to="bottom_laser_scan" />
-    </node>
-    
-    <group if="$(arg bottom_lidar_filter_enable)">
-        <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="laser_filter_right">
-            <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_right.yaml" />
+    <group if="$(arg bottom_lidar_driver_enable)">
+        <node name="bottom_rplidar_node" pkg="rplidar_ros" type="rplidarNode" output="screen">
+            <param name="channel_type"        type="string" value="udp"/>
+            <param name="udp_ip"              type="string" value="10.7.5.151"/>
+            <param name="frame_id"            type="string" value="bottom_laser_link"/>
+            <param name="inverted"            type="bool"   value="false"/>
+            <param name="angle_compensate"    type="bool"   value="true"/>
+            <param name="scan_mode"           type="string" value="Sensitivity"/>
+            <param name="scan_frequency"      type="int"  value="10"/>
             <remap from="scan" to="bottom_laser_scan" />
-            <remap from="scan_filtered" to="bottom_laser_scan_right" />
         </node>
 
-        <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="laser_filter_left">
-            <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_left.yaml" />
-            <remap from="scan" to="bottom_laser_scan" />
-            <remap from="scan_filtered" to="bottom_laser_scan_left" />
-        </node>
+        <group if="$(arg bottom_lidar_filter_enable)">
+            <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_right">
+                <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_right.yaml" />
+                <remap from="scan" to="bottom_laser_scan" />
+                <remap from="scan_filtered" to="bottom_laser_scan_right" />
+            </node>
 
-        <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="laser_filter_right">
-            <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_back.yaml" />
-            <remap from="scan" to="bottom_laser_scan" />
-            <remap from="scan_filtered" to="bottom_laser_scan_back" />
-        </node>
+            <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_left">
+                <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_left.yaml" />
+                <remap from="scan" to="bottom_laser_scan" />
+                <remap from="scan_filtered" to="bottom_laser_scan_left" />
+            </node>
 
-        <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
-            <param name="destination_frame" value="bottom_laser_link"/>
-            <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
-            <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right /bottom_laser_scan_back"/>
-            <param name="angle_min" type="double" value="-3.142"/>
-            <param name="angle_max" type="double" value="3.142"/>
-            <param name="range_min" type="double" value="0.15"/>
-            <param name="range_max" type="double" value="30.0"/>
-        </node>
+            <group if="$(arg bottom_lidar_back_filter_enable)">
+                <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_back">
+                    <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_back.yaml" />
+                    <remap from="scan" to="bottom_laser_scan" />
+                    <remap from="scan_filtered" to="bottom_laser_scan_back" />
+                </node>
+
+                <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
+                    <param name="destination_frame" value="bottom_laser_link"/>
+                    <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
+                    <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right /bottom_laser_scan_back"/>
+                    <param name="angle_min" type="double" value="-3.142"/>
+                    <param name="angle_max" type="double" value="3.142"/>
+                    <param name="range_min" type="double" value="0.15"/>
+                    <param name="range_max" type="double" value="30.0"/>
+                </node>
+            </group>
+            <group unless="$(arg bottom_lidar_back_filter_enable)">
+                <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
+                    <param name="destination_frame" value="bottom_laser_link"/>
+                    <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
+                    <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right"/>
+                    <param name="angle_min" type="double" value="-3.142"/>
+                    <param name="angle_max" type="double" value="3.142"/>
+                    <param name="range_min" type="double" value="0.15"/>
+                    <param name="range_max" type="double" value="30.0"/>
+                </node>
+            </group>
+
+        </group>
     </group>
 </launch>

--- a/launch/bottom_lidar.launch
+++ b/launch/bottom_lidar.launch
@@ -1,67 +1,66 @@
 <launch>
-    <arg name="bottom_laser" value="0.4859 0 0.1248 3.142 0 3.142 base_link bottom_laser_link"/>
-    <arg name="bottom_lidar_driver_enable"      value="$(optenv BOTTOM_LIDAR_DRIVER_ENABLE true)"/>
-    <arg name="bottom_lidar_filter_enable"      value="$(optenv BOTTOM_LIDAR_FILTER_ENABLE true)"/>
-    <arg name="bottom_lidar_back_filter_enable" value="$(optenv BOTTOM_LIDAR_BACK_FILTER_ENABLE false)"/>
+  <arg name="bottom_laser" value="0.4859 0 0.1248 3.142 0 3.142 base_link bottom_laser_link"/>
+  <arg name="bottom_lidar_driver_enable"      value="$(optenv BOTTOM_LIDAR_DRIVER_ENABLE true)"/>
+  <arg name="bottom_lidar_filter_enable"      value="$(optenv BOTTOM_LIDAR_FILTER_ENABLE true)"/>
+  <arg name="bottom_lidar_back_filter_enable" value="$(optenv BOTTOM_LIDAR_BACK_FILTER_ENABLE false)"/>
 
-    <env name="ROSCONSOLE_CONFIG_FILE" value="$(find rplidar_ros)/configs/custom_rosconsole.conf"/>
+  <env name="ROSCONSOLE_CONFIG_FILE" value="$(find rplidar_ros)/configs/custom_rosconsole.conf"/>
 
-    <node pkg="tf2_ros" type="static_transform_publisher" name="bottom_laser_tf" args="$(arg bottom_laser)" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="bottom_laser_tf" args="$(arg bottom_laser)" />
 
-    <group if="$(arg bottom_lidar_driver_enable)">
-        <node name="bottom_rplidar_node" pkg="rplidar_ros" type="rplidarNode" output="screen">
-            <param name="channel_type"        type="string" value="udp"/>
-            <param name="udp_ip"              type="string" value="10.7.5.151"/>
-            <param name="frame_id"            type="string" value="bottom_laser_link"/>
-            <param name="inverted"            type="bool"   value="false"/>
-            <param name="angle_compensate"    type="bool"   value="true"/>
-            <param name="scan_mode"           type="string" value="Sensitivity"/>
-            <param name="scan_frequency"      type="int"  value="10"/>
-            <remap from="scan" to="bottom_laser_scan" />
+  <group if="$(arg bottom_lidar_driver_enable)">
+    <node name="bottom_rplidar_node" pkg="rplidar_ros" type="rplidarNode" output="screen">
+      <param name="channel_type"        type="string" value="udp"/>
+      <param name="udp_ip"              type="string" value="10.7.5.151"/>
+      <param name="frame_id"            type="string" value="bottom_laser_link"/>
+      <param name="inverted"            type="bool"   value="false"/>
+      <param name="angle_compensate"    type="bool"   value="true"/>
+      <param name="scan_mode"           type="string" value="Sensitivity"/>
+      <param name="scan_frequency"      type="int"  value="10"/>
+      <remap from="scan" to="bottom_laser_scan" />
+    </node>
+
+    <group if="$(arg bottom_lidar_filter_enable)">
+      <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_right">
+        <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_right.yaml" />
+        <remap from="scan" to="bottom_laser_scan" />
+        <remap from="scan_filtered" to="bottom_laser_scan_right" />
+      </node>
+
+      <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_left">
+        <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_left.yaml" />
+        <remap from="scan" to="bottom_laser_scan" />
+        <remap from="scan_filtered" to="bottom_laser_scan_left" />
+      </node>
+
+      <group if="$(arg bottom_lidar_back_filter_enable)">
+        <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_back">
+          <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_back.yaml" />
+          <remap from="scan" to="bottom_laser_scan" />
+          <remap from="scan_filtered" to="bottom_laser_scan_back" />
         </node>
 
-        <group if="$(arg bottom_lidar_filter_enable)">
-            <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_right">
-                <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_right.yaml" />
-                <remap from="scan" to="bottom_laser_scan" />
-                <remap from="scan_filtered" to="bottom_laser_scan_right" />
-            </node>
-
-            <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_left">
-                <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_left.yaml" />
-                <remap from="scan" to="bottom_laser_scan" />
-                <remap from="scan_filtered" to="bottom_laser_scan_left" />
-            </node>
-
-            <group if="$(arg bottom_lidar_back_filter_enable)">
-                <node pkg="laser_filters" type="scan_to_scan_filter_chain" name="bottom_lidar_filter_back">
-                    <rosparam command="load" file="$(find rplidar_ros)/configs/bottom_lidar_filter_back.yaml" />
-                    <remap from="scan" to="bottom_laser_scan" />
-                    <remap from="scan_filtered" to="bottom_laser_scan_back" />
-                </node>
-
-                <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
-                    <param name="destination_frame" value="bottom_laser_link"/>
-                    <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
-                    <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right /bottom_laser_scan_back"/>
-                    <param name="angle_min" type="double" value="-3.142"/>
-                    <param name="angle_max" type="double" value="3.142"/>
-                    <param name="range_min" type="double" value="0.15"/>
-                    <param name="range_max" type="double" value="30.0"/>
-                </node>
-            </group>
-            <group unless="$(arg bottom_lidar_back_filter_enable)">
-                <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
-                    <param name="destination_frame" value="bottom_laser_link"/>
-                    <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
-                    <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right"/>
-                    <param name="angle_min" type="double" value="-3.142"/>
-                    <param name="angle_max" type="double" value="3.142"/>
-                    <param name="range_min" type="double" value="0.15"/>
-                    <param name="range_max" type="double" value="30.0"/>
-                </node>
-            </group>
-
-        </group>
+        <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
+          <param name="destination_frame" value="bottom_laser_link"/>
+          <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
+          <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right /bottom_laser_scan_back"/>
+          <param name="angle_min" type="double" value="-3.142"/>
+          <param name="angle_max" type="double" value="3.142"/>
+          <param name="range_min" type="double" value="0.15"/>
+          <param name="range_max" type="double" value="30.0"/>
+        </node>
+      </group>
+      <group unless="$(arg bottom_lidar_back_filter_enable)">
+        <node name="laserscan_multi_merger" pkg="ira_laser_tools" type="laserscan_multi_merger" output="screen" respawn="true">
+          <param name="destination_frame" value="bottom_laser_link"/>
+          <param name="scan_destination_topic" value="/bottom_laser_scan_filtered"/>
+          <param name="laserscan_topics" value="/bottom_laser_scan_left /bottom_laser_scan_right"/>
+          <param name="angle_min" type="double" value="-3.142"/>
+          <param name="angle_max" type="double" value="3.142"/>
+          <param name="range_min" type="double" value="0.15"/>
+          <param name="range_max" type="double" value="30.0"/>
+        </node>
+      </group>
     </group>
+  </group>
 </launch>

--- a/launch/bottom_lidar.launch
+++ b/launch/bottom_lidar.launch
@@ -1,10 +1,10 @@
 <launch>
-    <arg name="bottom_laser" value="0.4859 0 0.1248 3.142 0 3.142 base_link bottom_laser_link 10"/>
+    <arg name="bottom_laser" value="0.4859 0 0.1248 3.142 0 3.142 base_link bottom_laser_link"/>
     <arg name="bottom_lidar_filter_enable"    value="$(optenv BOTTOM_LIDAR_FILTER_ENABLE false)"/>
 
     <env name="ROSCONSOLE_CONFIG_FILE" value="$(find rplidar_ros)/configs/custom_rosconsole.conf"/>
 
-    <node pkg="tf" type="static_transform_publisher" name="bottom_laser_tf" args="$(arg bottom_laser)" />
+    <node pkg="tf2_ros" type="static_transform_publisher" name="bottom_laser_tf" args="$(arg bottom_laser)" />
 
     <node name="bottom_rplidar_node" pkg="rplidar_ros" type="rplidarNode" output="screen">
         <param name="channel_type"        type="string" value="udp"/>  
@@ -47,4 +47,3 @@
         </node>
     </group>
 </launch>
-  

--- a/launch/side_lidar.launch
+++ b/launch/side_lidar.launch
@@ -27,5 +27,4 @@
     <param name="scan_frequency"      type="int"  value="10"/>
     <remap from="scan" to="left_laser_scan"/>
   </node>
-
 </launch>

--- a/launch/side_lidar.launch
+++ b/launch/side_lidar.launch
@@ -2,13 +2,13 @@
 
   <!-- publish tf -->
   <!-- left -->
-  <node pkg="tf" type="static_transform_publisher" name="left_laser_tf" args="0.233070 0.149933 1.032733 1.571 1.396260 0 base_link left_laser_link 10" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="left_laser_tf" args="0.25 0.13339 1.000859 1.571 1.3955 0.0 base_link left_laser_link" />
   <!-- right -->
-  <node pkg="tf" type="static_transform_publisher" name="right_laser_tf" args="0.233070 -0.149933  1.032733 -1.571 1.396260 0 base_link right_laser_link 10" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="right_laser_tf" args="0.25 -0.13339 1.000859 -1.571 1.3955 0.0 base_link right_laser_link" />
   
   <node name="right_rplidar_node" pkg="rplidar_ros"  type="rplidarNode" output="screen">
-    <param name="channel_type"        type="string" value="udp"/>  
-    <param name="udp_ip"              type="string" value="10.7.5.152"/>  
+    <param name="channel_type"        type="string" value="udp"/>
+    <param name="udp_ip"              type="string" value="10.7.5.152"/>
     <param name="frame_id"            type="string" value="right_laser_link"/>
     <param name="inverted"            type="bool"   value="false"/>
     <param name="angle_compensate"    type="bool"   value="true"/>
@@ -27,4 +27,5 @@
     <param name="scan_frequency"      type="int"  value="10"/>
     <remap from="scan" to="left_laser_scan"/>
   </node>
+
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <package>
   <name>rplidar_ros</name>
-  <version>1.10.0</version>
+  <version>0.1.0</version>
   <description>The rplidar ros package, support rplidar A2/A1 and A3/S1</description>
 
-  <maintainer email="ros@slamtec.com">Slamtec ROS Maintainer</maintainer>
+  <maintainer email="edwin.tan@kabam.ai">Edwin Tan</maintainer>
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
This PR is to
- Add arguments to the launch file to enable/disable bottom lidar filters
- Reduce the FOV of the bottom lidar left and right filter for the front

[launch_file_args_testing_video.webm](https://github.com/user-attachments/assets/cc65d707-20bb-4cb8-ad35-7a3ddfedb796)

Timestamp
- 0:00 - Set parameters
    - `BOTTOM_LIDAR_DRIVER_ENABLE` false 
    - `BOTTOM_LIDAR_FILTER_ENABLE` false
    - `BOTTOM_LIDAR_BACK_FILTER_ENABLE` false
- 0:15 `/bottom_laser_scan` topic is not publishing
- 0:30 - Set parameters
    - `BOTTOM_LIDAR_DRIVER_ENABLE` true
    - `BOTTOM_LIDAR_FILTER_ENABLE` false
    - `BOTTOM_LIDAR_BACK_FILTER_ENABLE` false
- 0:52 - `/bottom_laser_scan` topic is publishing with data points inside the robot footprint (green box) which are at the back of the lidar
- 1:09 - `/bottom_laser_scan_filtered` topic is not publishing
- 1:17 - Set parameters
    - `BOTTOM_LIDAR_DRIVER_ENABLE` true
    - `BOTTOM_LIDAR_FILTER_ENABLE` true
    - `BOTTOM_LIDAR_BACK_FILTER_ENABLE` false
- 1:40 - `/bottom_laser_scan_filtered` topic is publishing without any points at the back of the lidar
- 1:50 - Set parameters
    - `BOTTOM_LIDAR_DRIVER_ENABLE` true
    - `BOTTOM_LIDAR_FILTER_ENABLE` true
    - `BOTTOM_LIDAR_BACK_FILTER_ENABLE` true
- 2:14 - `/bottom_laser_scan_filtered` topic is publishing with data points inside the robot footprint (green box) which are at the back of the lidar